### PR TITLE
support SVG image elements

### DIFF
--- a/tasks/grunt-rev-md5.js
+++ b/tasks/grunt-rev-md5.js
@@ -13,7 +13,7 @@ module.exports = function (grunt) {
 
 	
 
-	var reghtml = new RegExp(/<(?:img|link|source|script).*\b(?:href|src)\b=['"]([^ ]+)['"].*\/?>/ig);
+	var reghtml = new RegExp(/<(?:img|image|link|source|script).*\b(?:href|src)\b=['"]([^ ]+)['"].*\/?>/ig);
 	var regcss = new RegExp(/url\(([^)]+)\)/ig);
 
 	var writeln = grunt.log.writeln;


### PR DESCRIPTION
SVGs embedded within HTML use `<image>` instead of `<img>`.
